### PR TITLE
JITServer Helm Chart for version upgrade to 0.26

### DIFF
--- a/helm-chart/index.yaml
+++ b/helm-chart/index.yaml
@@ -23,10 +23,49 @@ apiVersion: v1
 entries:
   openj9-jitserver-chart:
   - apiVersion: v2
+    appVersion: 0.26.0
+    created: "2021-05-05T12:49:24.7906493-04:00"
+    description: |-
+      Eclipse OpenJ9 JITServer Helm Chart. 
+      
+      License
+      
+      This chart is made available under the terms of the Eclipse Public License 2.0 
+      which accompanies this distribution and is available at https://www.eclipse.org/legal/epl-2.0/ 
+      or the Apache License, Version 2.0 which accompanies this distribution and 
+      is available at https://www.apache.org/licenses/LICENSE-2.0.
+      
+      The JDK binaries installed by this chart are licensed under the GPLv2+CE.
+    digest: ef9b64325c5c68f8c1cda3eebfd712b22a90d9964341aaa4b46312b01fbae425
+    icon: https://pbs.twimg.com/profile_images/910853900181364736/bmWkKoLn_400x400.jpg
+    keywords:
+    - amd64
+    - ppc64le
+    - Java
+    - Eclipse
+    - OpenJ9
+    - JITServer
+    - JVM
+    - JIT
+    name: openj9-jitserver-chart
+    type: application
+    urls:
+    - https://github.com/eclipse-openj9/openj9-utils/files/6428928/openj9-jitserver-chart-0.26.0.tar.gz
+    version: 0.26.0
+  - apiVersion: v2
     appVersion: 0.24.0
     created: "2021-01-11T10:37:05.164743965-08:00"
-    description: "Eclipse OpenJ9 JITServer Helm Chart. \n\nLicense\nBy installing
-      this product you accept the Eclipse Public License v2.0: https://www.eclipse.org/legal/epl-2.0/."
+    description: |-
+      Eclipse OpenJ9 JITServer Helm Chart. 
+      
+      License
+      
+      This chart is made available under the terms of the Eclipse Public License 2.0 
+      which accompanies this distribution and is available at https://www.eclipse.org/legal/epl-2.0/ 
+      or the Apache License, Version 2.0 which accompanies this distribution and 
+      is available at https://www.apache.org/licenses/LICENSE-2.0.
+      
+      The JDK binaries installed by this chart are licensed under the GPLv2+CE.
     digest: 20b6f828730be12cc09f26412416bbd1791c96ae2fa077552b6e0fd7135bc4d7
     icon: https://pbs.twimg.com/profile_images/910853900181364736/bmWkKoLn_400x400.jpg
     keywords:
@@ -43,4 +82,4 @@ entries:
     urls:
     - https://github.com/eclipse/openj9-utils/files/5825427/openj9-jitserver-chart-0.24.0.tar.gz
     version: 0.24.0
-generated: "2021-01-11T10:37:05.162604577-08:00"
+generated: "2021-05-05T13:05:48.8906766-04:00"

--- a/helm-chart/openj9-jitserver-chart/Chart.yaml
+++ b/helm-chart/openj9-jitserver-chart/Chart.yaml
@@ -44,6 +44,6 @@ keywords:
   - JVM
   - JIT
 type: application
-version: 0.24.0
-appVersion: 0.24.0
+version: 0.26.0
+appVersion: 0.26.0
 icon: https://pbs.twimg.com/profile_images/910853900181364736/bmWkKoLn_400x400.jpg

--- a/helm-chart/openj9-jitserver-chart/values.yaml
+++ b/helm-chart/openj9-jitserver-chart/values.yaml
@@ -24,7 +24,7 @@ replicaCount: 1
 
 image:
   repository: adoptopenjdk
-  tag: 8u282-b08-jdk-openj9-0.24.0
+  tag: jdk8u292-b10_openj9-0.26.0
   pullPolicy: Always
 
 env:


### PR DESCRIPTION
This PR updates the JITServer Helm Chart to 0.26 to follow OpenJ9 0.26 release. 

Binary Helm Chart: [openj9-jitserver-chart-0.26.0.tar.gz](https://github.com/eclipse-openj9/openj9-utils/files/6428928/openj9-jitserver-chart-0.26.0.tar.gz)

Reference: https://github.com/eclipse/openj9-utils/issues/46

Signed-off-by: Chris Chong <Zichun.Chong@ibm.com>