### PR TITLE
Redirect networking clients data to file

### DIFF
--- a/perf-tool/include/client.hpp
+++ b/perf-tool/include/client.hpp
@@ -15,18 +15,22 @@ public:
 private:
     int socketFd, portno;
     std::string hostname;
+    std::string clientLogPath;
     bool interactive_mode, keepPolling = true;
     struct pollfd pollFds[2];
+    FILE * clientLogFile;
 
     /*
      * Function members
      */
 protected:
 public:
-    Client(const int _portno, const std::string _hostname = "localhost", bool _interactive_mode = false);
+    Client(const int _portno, const std::string _clientLogPath, const std::string _hostname = "localhost", bool _interactive_mode = false);
 
     void startClient(void);
     void closeClient(void);
+    void openFile(void);
+    void closeFile(void);
 
 private:
     void openServerConnection(void);

--- a/perf-tool/src/server.cpp
+++ b/perf-tool/src/server.cpp
@@ -246,6 +246,7 @@ void Server::sendMessage(const int socketFd, const json& message, std::string ev
     log["eventType"] = event;
     log["timestamp"] = nano;
     std::string result = log.dump(2, ' ', true);
+    result += ",\n";
     int n, total = 0;
     size_t length = result.size();
     const char *buffer = result.data();
@@ -292,7 +293,7 @@ void Server::shutDownServer()
         perfThread.join();
     }
 
-    handleMessagingClients("Server shutting down", "");
+    handleMessagingClients("Server shutting down", "ShutdownEvent");
 
     /* close off commands, logs, and network client sockets */
     for (int i = 0; i < activeNetworkClients; i++)


### PR DESCRIPTION
While starting the client pass port number and optional
--log file name to which data will be redirected and host.
Default log path is clientLogs.json

Eg: `./a.out --portNo=port --log=logname --host=localhost`
or use short notations as below:
`./a.out --p=port --l=logname --h=localhost`
Use -u for usage:
`./a.out -u`

Fixes: #67

Signed-off-by: Ravali Yatham <rayatha1@in.ibm.com>