### PR TITLE
Add option to turn on/off method enter/exit capability

### DIFF
--- a/perf-tool/README.md
+++ b/perf-tool/README.md
@@ -34,8 +34,9 @@ These commands are passed to the agent on start up. The format of the commands s
 | --- | ---| --- |
 | commandFile | Path to file | Provide the agent with a path to a file containing commands (see [Function Commands](#function-commands)) that will be fed to the agent in headless mode |
 | logFile | Path to file | Provide the agent with a location to place a log file for agent output. The agent will create a new file if it does not exist. |
-| portNo | Port Number | Provide the agent with a port to start the server on. The default port is 9002.  
+| portNo | Port Number | Provide the agent with a port to start the server on. The default port is 9002. | 
 | verbose | 1,2,3 | Provide the agent with a degree of verbosity to show the additional information. |
+| methodEnterCapability | "on" or "off" | Allow agent to collect method enter/exit traces. Default is "off" |
 
 
 # Function Commands

--- a/perf-tool/src/infra.cpp
+++ b/perf-tool/src/infra.cpp
@@ -333,12 +333,13 @@ JNIEXPORT void JNICALL VMInit(jvmtiEnv *jvmtiEnv, JNIEnv* jni_env, jthread threa
 }
 
 JNIEXPORT void JNICALL VMDeath(jvmtiEnv *jvmtiEnv, JNIEnv* jni_env) {
+    if (verbose >= INFO)
+        printf("VM shutting down.\n");
     if (server)
     {
         server->shutDownServer();
         delete server;
         server = NULL;
     }
-    if (verbose >= WARN)
-        printf("VM shutting down.\n");
+
 }


### PR DESCRIPTION
Since method enter/exit tracing capability can interfere
with the JIT compiler optimizer, it's better to turn off
this capability by default, but allow the user to turn it
on, if she wants to use it.
This commit adds a new option for the agent called:
`methodEnterCapability` with two possible values "on" or "off".
The default is "off".
Note that enabling method enter/exit tracing capability does
not enable tracing itself. Starting/stopping the tracing
needs to be done with json commands like with any other tracing.

Fixes: #57

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>