### PR TITLE
Prevent crashes at JVM shutdown

### DIFF
--- a/perf-tool/include/server.hpp
+++ b/perf-tool/include/server.hpp
@@ -27,6 +27,7 @@
 #include <thread>
 #include <poll.h>
 #include <vector>
+#include <mutex>
 
 #include "serverClients.hpp"
 #include "json.hpp"
@@ -46,6 +47,7 @@ class Server
      */
 protected:
 public:
+    static std::mutex serverMutex;
 private:
     int serverSocketFd = -1, activeNetworkClients = 0, portNo;
     bool headlessMode = true, keepPolling = true;

--- a/perf-tool/src/server.cpp
+++ b/perf-tool/src/server.cpp
@@ -45,6 +45,7 @@
 
 using namespace std;
 using json = nlohmann::json;
+std::mutex Server::serverMutex;
 
 Server::Server(int portNo, const string &commandFileName, const string &logFileName)
 {


### PR DESCRIPTION
If tracing of an event is enabled while the JVM shuts down,
a crash can happen because the `Server` object is destroyed,
while the tracing thread still wants to use this object.
This commit prevents crashes during shutdown by adding a lock.
When the `Server` object is used, the current thread will hold
a `serverMonitor` to prevent the thread executing the `VMDeath`
event from destroying the `Server` object. This will also prevent
the output from different tracing threads from being interleaved.

Fixes: #30

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>