### PR TITLE
Avoid inconsistency in verbose data collection

### DIFF
--- a/perf-tool/src/verboseLog.cpp
+++ b/perf-tool/src/verboseLog.cpp
@@ -35,8 +35,12 @@ std::atomic<int> verboseSampleRate {1};
 
 void VerboseLogSubscriber::setVerboseGCLogSampleRate(int rate) 
 {
-    if (rate > 0)
-        verboseSampleRate = rate;
+    if (rate > 1)
+    {
+        if (verbose >= Verbose::INFO)
+            printf("Resetting sampling rate to 1 to avoid inconsistency in output data\n");
+        verboseSampleRate = 1;
+    }
 }
 
 void VerboseLogSubscriber::Subscribe()


### PR DESCRIPTION
We are collecting only nth sample of events which
results in missing sections within one gc cycle. So
reset samplerate to 1 even if user specifies sampleRate
greater than 1

Fixes: #41

Signed-off-by: Ravali Yatham <rayatha1@in.ibm.com>