### PR TITLE
Reduce performance overhead of perf agent 

### DIFF
--- a/perf-tool/include/agentOptions.hpp
+++ b/perf-tool/include/agentOptions.hpp
@@ -30,7 +30,5 @@ using json = nlohmann::json;
 
 extern jvmtiEnv *jvmti;
 extern JavaVM *javaVM;
-void agentCommand(const json& jCommand);
-
 
 #endif /* agent_Options_H */

--- a/perf-tool/include/serverClients.hpp
+++ b/perf-tool/include/serverClients.hpp
@@ -35,7 +35,7 @@ class ServerConstants
 public:
     static constexpr int NUM_CLIENTS = 5;
     static constexpr int BASE_POLLS = 1;
-    static constexpr int POLL_INTERVALS = 250;
+    static constexpr int POLL_INTERVALS = 500;
     static constexpr int COMMAND_INTERVALS = 500;
     static constexpr int BUFFER_SIZE = 512;
     static constexpr int DEFAULT_PORT = 0;
@@ -62,32 +62,6 @@ public:
     int getSocketFd(void);
     void closeFd(void);
     std::string handlePoll();
-};
-
-class CommandClient
-{
-    /*
-     * Data members
-     */
-protected:
-public:
-private:
-    int currentInterval = ServerConstants::COMMAND_INTERVALS;
-    FILE * commandsFile;
-    json commands;
-
-    /*
-     * Function members
-     */
-protected:
-private:
-    void execCommand(json command);
-
-public:
-    CommandClient(const std::string filename);
-
-    void closeFile(void);
-    json handlePoll(void);
 };
 
 class LoggingClient

--- a/perf-tool/src/agentOptions.cpp
+++ b/perf-tool/src/agentOptions.cpp
@@ -34,6 +34,7 @@
 #include "objectalloc.hpp"
 #include "exception.hpp"
 #include "methodEntry.hpp"
+#include "server.hpp"
 #include "verboseLog.hpp"
 
 #include "json.hpp"
@@ -388,7 +389,7 @@ void modifyJLM(const std::string& function, const std::string& command)
 }
 
 
-void agentCommand(const json& jCommand)
+void Server::agentCommand(const json& jCommand)
 {
     jvmtiCapabilities capa;
     jvmtiError error;
@@ -466,7 +467,7 @@ void agentCommand(const json& jCommand)
             }
             modifyMethodEntryEvents(function, command, sampleRate, stackTraceDepth, classFilter, methodFilter, signatureFilter);
         }
-       else if (!function.compare("methodExitEvents"))
+        else if (!function.compare("methodExitEvents"))
         {
             std::string classFilter, methodFilter, signatureFilter;
             if (jCommand.contains("filter"))
@@ -489,6 +490,18 @@ void agentCommand(const json& jCommand)
         else if (!function.compare("jlm"))
         {
             modifyJLM(function, command);
+        }
+        else if (!function.compare("perf"))
+        {
+            if (jCommand.contains("time"))
+            {
+                startPerfThread(jCommand["time"]);
+            }
+            else
+            {
+                if (verbose >= Verbose::WARN)
+                    printf("perf command must contain a 'time' field. Command ignored\n");
+            }
         }
         else
         {

--- a/perf-tool/src/serverClients.cpp
+++ b/perf-tool/src/serverClients.cpp
@@ -64,11 +64,12 @@ int NetworkClient::getSocketFd(void)
 void NetworkClient::closeFd(void)
 {
     close(socketFd);
+    socketFd = -1;
 }
 
 LoggingClient::LoggingClient(const string filename)
 {
-    logFile = fopen(filename.c_str() ,"a");
+    logFile = fopen(filename.c_str() ,"w");
     if (logFile == NULL)
     {
         fprintf(stderr, "Error opening  %s\n", filename.c_str());
@@ -89,6 +90,7 @@ void LoggingClient::closeFile(void)
         fputs("\n]\n", logFile);
         
         fclose(logFile);
+        logFile = NULL;
     }
 }
 
@@ -109,51 +111,4 @@ void LoggingClient::logData(const json& message, std::string event, const std::s
     }
 }
 
-CommandClient::CommandClient(const string filename)
-{
-    commandsFile = fopen(filename.c_str() ,"r");
-    if (commandsFile == NULL)
-    {
-        fprintf(stderr, "commands file %s doesn't exists\n", filename.c_str());
-        exit(0);
-    }
-    try
-    {
-        commands = json::parse(commandsFile);
-    }
-    catch (const std::exception& e)
-    {
-        fprintf(stderr, "%s and Improper command received from: %s \n", e.what(), filename.c_str());
-        exit(0);
-    }
-}
 
-void CommandClient::closeFile(void)
-{
-    if (commandsFile)
-    {
-        fclose(commandsFile);
-    }
-}
-
-json CommandClient::handlePoll()
-{
-    static int commandNumber = 0;
-    static const int numCommands = commands.size();
-    json j;
-
-    if (currentInterval <= 0)
-    {
-        if (commandNumber < numCommands)
-        {
-            return commands[commandNumber++];
-        }
-        currentInterval = ServerConstants::COMMAND_INTERVALS;
-    }
-    else
-    {
-        currentInterval = currentInterval - ServerConstants::POLL_INTERVALS;
-    }
-
-    return j;
-}


### PR DESCRIPTION
This commit fixes a performance bug caused by a tight loop
that permanently checks whether there are delayed commands
to be processed. This bug does not show if we give the agent
a port option to listen to, because in that case the loop
mentioned above includes a poll operation with a timeout of 250ms.

This commit also makes the following changes:
- All commands coming for the command file are read during agent load
  and inserted into a linked list sorted by the time when the
  command needs to be applied
- Replaced the code that was always sorting the array of commands
  (now we insert in the right place to keep the collection always sorted)
- Removed some of the functions that are no longer needed
- Removed some of the conversions from string to json and back
- Increased the poll timeout value from 250ms to 500ms

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>