### PR TITLE
Modified the arguments for JITServer to redirect output

### DIFF
--- a/helm-chart/index.yaml
+++ b/helm-chart/index.yaml
@@ -23,7 +23,7 @@ entries:
   openj9-jitserver-chart:
   - apiVersion: v2
     appVersion: 0.26.0
-    created: "2021-06-24T05:57:33.391285898-07:00"
+    created: "2021-06-24T13:06:19.73138277-07:00"
     description: |-
       Eclipse OpenJ9 JITServer Helm Chart. 
       
@@ -35,7 +35,7 @@ entries:
       is available at https://www.apache.org/licenses/LICENSE-2.0.
       
       The JDK binaries installed by this chart are licensed under the GPLv2+CE.
-    digest: ff381fe73447c4fa1b0ff2f471ae1cacc4a8f77c2ed1f545e3f6af10752e38ac
+    digest: 7210874a18913b41975d50a583803172e84cd00ca7f462a10225a1b0ba427839
     icon: https://pbs.twimg.com/profile_images/910853900181364736/bmWkKoLn_400x400.jpg
     keywords:
     - amd64
@@ -49,7 +49,7 @@ entries:
     name: openj9-jitserver-chart
     type: application
     urls:
-    - https://github.com/eclipse-openj9/openj9-utils/files/6709349/openj9-jitserver-chart-0.26.0.tar.gz
+    - https://github.com/eclipse-openj9/openj9-utils/files/6711865/openj9-jitserver-chart-0.26.0.tar.gz
     version: 0.26.0
   - apiVersion: v2
     appVersion: 0.24.0
@@ -81,4 +81,4 @@ entries:
     urls:
     - https://github.com/eclipse/openj9-utils/files/5825427/openj9-jitserver-chart-0.24.0.tar.gz
     version: 0.24.0
-generated: "2021-06-24T05:57:33.389797083-07:00"
+generated: "2021-06-24T13:06:19.729847316-07:00"

--- a/helm-chart/openj9-jitserver-chart/templates/deployment.yaml
+++ b/helm-chart/openj9-jitserver-chart/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           command: ["/bin/bash"]
-          args: ["-c", "jitserver &> /tmp/output.log"]
+          args: ["-c", "jitserver 2>&1 | tee  /tmp/output.log"]
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
changed the args for JITServer in deployment.yaml to redirect
output to stdout and to file "output.log". Previously the output
was redirected to the file "output.log" only.

Binary Helm Chart: [openj9-jitserver-chart-0.26.0.tar.gz](https://github.com/eclipse-openj9/openj9-utils/files/6711865/openj9-jitserver-chart-0.26.0.tar.gz)


Signed-off-by: Eman Elsabban <eman.elsaban1@gmail.com>