### PR TITLE
Add table with tags for ibm-semeru-runtimes images

### DIFF
--- a/helm-chart/openj9-jitserver-chart/README.md
+++ b/helm-chart/openj9-jitserver-chart/README.md
@@ -23,7 +23,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-excepti
 # Eclipse OpenJ9 JITServer Helm Chart
 
 ## Introduction.
-The OpenJ9 JITServer Helm Chart allows you to deploy, manage JITServer technology into Kubernetes or OpenShift clusters and make it possible for your Java applications to take advantage of it. JITServer is a technology that offers relief from the negative side-effects of the JIT compilation which are mostly felt in short lived applications running in resource constrained environments. The idea behind the technology is to decouple the JIT compiler from the JVM, containerize it and let it run as-a-service, in the cloud, where it can be managed intelligently by an off-the-shelf container orchestrator like k8s. JITServer is available as a "tech preview" in the OpenJ9 JVM and is supported on Linux on x86-64, Linux on Power and Linux on Z running Java8 or Java11. For the most up to date information, please check supported configurations at [JITServer technology introduction](https://www.eclipse.org/openj9/docs/jitserver/). 
+The OpenJ9 JITServer Helm Chart allows you to deploy, manage JITServer technology into Kubernetes or OpenShift clusters and make it possible for your Java applications to take advantage of it. JITServer is a technology that offers relief from the negative side-effects of the JIT compilation which are mostly felt in short lived applications running in resource constrained environments. The idea behind the technology is to decouple the JIT compiler from the JVM, containerize it and let it run as-a-service, in the cloud, where it can be managed intelligently by an off-the-shelf container orchestrator like k8s. JITServer is available as a "tech preview" in the OpenJ9 JVM and is supported on Linux on x86-64, Linux on Power and Linux on Z running Java8 or Java11. For the most up to date information, please check supported configurations at [JITServer technology introduction](https://www.eclipse.org/openj9/docs/jitserver/).
 
 ## Getting started with OpenJ9 JITServer Technology.
 JITServer technology can be used for any Java application running on release 0.18 (or newer) of Open9 on supported Java versions and Linux platforms. You can make use of JITServer technology following the steps below:
@@ -35,7 +35,7 @@ JITServer technology can be used for any Java application running on release 0.1
 #### a. Verify the application JDK version and select the appropriate JITServer image.
 Important: The client JVM and the JITServer instance it connects to must use the same (compatible) version. The easiest way to ensure this is using the same release for the JITServer JDK as used by the  application.
 
-Inside your Java application image, run `java -version` to check the JDK release version. In the example below, the `0.21.0` release of Java 11 JDK on `Linux amd64` architecture is used as shown in `build openj9-0.21.0, JRE 11 Linux amd64-64-Bit`. 
+Inside your Java application image, run `java -version` to check the JDK release version. In the example below, the `0.21.0` release of Java 11 JDK on `Linux amd64` architecture is used as shown in `build openj9-0.21.0, JRE 11 Linux amd64-64-Bit`.
 ```bash
 $ java -version
 openjdk version "11.0.8" 2020-07-14
@@ -51,7 +51,7 @@ Find the corresponding image from [AdoptOpenJDK Docker Hub](https://hub.docker.c
 #### b. Install the JITServer using the selected image and the Helm Chart.
 Add OpenJ9 JITServer helm chart repository to the Helm client.
 ``` bash
-helm repo add openj9 https://raw.githubusercontent.com/eclipse/openj9-utils/master/helm-chart/ 
+helm repo add openj9 https://raw.githubusercontent.com/eclipse/openj9-utils/master/helm-chart/
 helm repo update
 helm search repo openj9-jitserver-chart
 ```
@@ -61,23 +61,23 @@ Install OpenJ9 JITServer helm chart by following below command.
 helm install jitserver-release openj9-jitserver-chart
 ```
 
-This chart deploys a JITServer instance with latest OpenJ9 Java 8 release on x86 platform by default. If your application uses a different version of Java, please include the option `--set image.tag="REPLACE_IMAGE_TAG"` in above command which overrides below section in `Values.yaml`. 
+This chart deploys a JITServer instance with latest OpenJ9 Java 8 release on x86 platform by default. If your application uses a different version of Java, please include the option `--set image.tag="REPLACE_IMAGE_TAG"` in above command which overrides below section in `Values.yaml`.
 ```yaml
 image:
   tag: 8-openj9
 ```
 
-Currently, JITServer is supported on Java versions 8 and 11. 
+Currently, JITServer is supported on Java versions 8 and 11.
 
 ### 2. Enable your application to use JITServer.
 Once the JITServer is deployed, you can enable your application to use JITServer by adding the following JVM option as an environment variable into your Java application container.
 
-Service names can be found by `kubectl get service`, `<serverport>` is set to `38400` by default. 
+Service names can be found by `kubectl get service`, `<serverport>` is set to `38400` by default.
 ``` bash
 JAVA_OPTIONS = "-XX:+UseJITServer -XX:JITServerAddress=<servicename> -XX:JITServerPort=<serverport>"
 ```
 
-`<servicename>` is set automatically by helm, and you may change `<serverport>` by including option `--set service.port="REPLACE_PORT_NUMBER"`. This option overrides below section in `Values.yaml`. 
+`<servicename>` is set automatically by helm, and you may change `<serverport>` by including option `--set service.port="REPLACE_PORT_NUMBER"`. This option overrides below section in `Values.yaml`.
 ```yaml
 service:
   port: 38400
@@ -86,7 +86,7 @@ service:
 Setting the `JAVA_OPTIONS` environment variable on a new or an already in production application depends on your application build/deployment pipeline. For more detailed instructions on how to redeploy your application with the above environment variable changes, please read through [this tutorial](./enable-jitserver.md). The tutorial shows how to enable JITServer technology for an example OpenLiberty Java application.
 
 ## JITServer considerations and platform support
-### How to select a platform and a Java version 
+### How to select a platform and a Java version
 Platforms are handled by multi-arch images from AdoptOpenJDK docker hub, thus platform specific JITServer is deployed based on which platform the install is being done on. The JITServer Java version has to exactly match the application Java version. For example, Java 8 applications need Java 8 JITServer running on the exact same JDK version. (See details above)
 
 If your application uses a different version of Java, please include the option `--set image.tag="REPLACE_IMAGE_TAG"` in the `helm install` command which overrides below section in `Values.yaml`.
@@ -113,8 +113,19 @@ image:
 
 The complete list of avaliable images and tags can be found at [AdoptOpenJDK Docker Hub](https://hub.docker.com/_/adoptopenjdk?tab=tags).
 
+A short list of tags from the `docker.io/ibm-semeru-runtime` repository is included here:
+
+OpenJ9 Release | Java 8             | Java 11              | Java 17
+---------------|--------------------|----------------------|------------------
+0.27.0         | open-8u302-b08-jre | open-11.0.12_7-jre   |
+0.29.0         | open-8u312-b07-jre | open-11.0.13_8-jre   |
+0.29.1         |                    |                      | open-17.0.1_12-jre
+0.30.0         | open-8u322-b06-jre | open-11.0.14_8-jre   | open-17.0.2_8-jre
+0.30.1         |                    | open-11.0.14.1_1-jre |
+0.32.0         | open-8u332-b09-jre | open-11.0.15_10-jre  | open-17.0.3_7-jre
+
 ### JITServer and application deployment topology considerations
-One or more application(s) can connect to one JITServer instance as long as they are running the same JDK version and enough resources are allocated for JITServer. However, a single application should not be allowed to connect to multiple JITServer instances. 
+One or more application(s) can connect to one JITServer instance as long as they are running the same JDK version and enough resources are allocated for JITServer. However, a single application should not be allowed to connect to multiple JITServer instances.
 
 JITServer can be deployed either on the same node or on a different node from the java application. There are benefits from both methods.
 
@@ -122,11 +133,11 @@ JITServer can be deployed either on the same node or on a different node from th
 If the node that java application runs on has enough resources, deploying JITServer on the same node is recommended since this reduces networking overheads and maximizes JITServer performance. Note that this may not always be possible, if you want to connect multiple JVM clients to a single JITServer instance.
 
 * Deploy JITServer on a different node as the java application
-If the node that java application runs on does not have enough CPU or memory resources, JITServer can be deployed on a different node. 
+If the node that java application runs on does not have enough CPU or memory resources, JITServer can be deployed on a different node.
 
 You may specify the node to deploy on by editing `affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution[].values[]` in `Values.yaml`. Node names can be found by `kubectl get nodes`.
 ``` yaml
-affinity: 
+affinity:
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:
         - key: kubernetes.io/hostname
@@ -167,7 +178,7 @@ Welcome to OpenJ9 JITServer Helm Chart, the application has been deployed succes
 ```
 
 ### Upgrade JITServer JDK upon application JDK upgrade.
-The JITServer instance must be compatible with the application JDK it serves. The easiest way to ensure this is using the same OpenJ9 release on both JITServer JDK and application JDK. Please follow [Step 1a](./README.md#a-verify-the-application-jdk-version-and-select-the-appropriate-jitserver-image) to find out application JDK build version before proceeding. 
+The JITServer instance must be compatible with the application JDK it serves. The easiest way to ensure this is using the same OpenJ9 release on both JITServer JDK and application JDK. Please follow [Step 1a](./README.md#a-verify-the-application-jdk-version-and-select-the-appropriate-jitserver-image) to find out application JDK build version before proceeding.
 
 #### Scenario 1: All applications are being upgraded to a newer JDK version.
 If all applications are being upgraded to a newer version of OpenJ9 JDK, you may perform a `helm upgrade` to upgrade the JITServer instances to be compatible with your applications. Replace the `REPLACE_IMAGE_TAG` with the desired image tag of the JITServer to be deployed.
@@ -176,7 +187,7 @@ helm upgrade --set image.tag="REPLACE_IMAGE_TAG" jitserver-release openj9-jitser
 ```
 
 #### Scenario 2: Only some applications are being upgraded to a newer version of JDK.
-If some applications are upgraded to a newer OpenJ9 JDK version while others are still using the older version of OpenJ9 JDK, you need to keep the existing JITServer and deploy another JITServer instance that is compatible with newer version of JDK. Replace `REPLACE_IMAGE_TAG` with the desired image tag to be deployed as a JITServer instance. 
+If some applications are upgraded to a newer OpenJ9 JDK version while others are still using the older version of OpenJ9 JDK, you need to keep the existing JITServer and deploy another JITServer instance that is compatible with newer version of JDK. Replace `REPLACE_IMAGE_TAG` with the desired image tag to be deployed as a JITServer instance.
 ```bash
 helm install --set image.tag="REPLACE_IMAGE_TAG" jitserver-release-latest openj9-jitserver-chart
 ```
@@ -187,7 +198,7 @@ helm delete jitserver-release
 
 ### Removing the JITServer
 Avoid removing the JITServer instance before applications terminate. If the memory limit for the container running the application JDK has been set based on the assumption that JITServer handles all JIT compilations, the application may experience a native out-of-memory scenario and be terminated.
-Once all applications are retired, you can safely remove the JITServer instance. 
+Once all applications are retired, you can safely remove the JITServer instance.
 ``` bash
 helm delete jitserver-release
 ```


### PR DESCRIPTION
This table is useful if the user wants to use the Helm chart
to deploy a JITServer instance for Java11/Java17 or for a different
release other than the most current one (saves him some time
searching through dockerhub).

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>