### PR TITLE
Update JITServer Helm chart for OpenJ9 0.33.1

### DIFF
--- a/helm-chart/index.yaml
+++ b/helm-chart/index.yaml
@@ -23,6 +23,36 @@ apiVersion: v1
 entries:
   openj9-jitserver-chart:
   - apiVersion: v2
+    appVersion: 0.33.1
+    created: "2022-08-29T09:15:06.661908609-07:00"
+    description: |-
+      Eclipse OpenJ9 JITServer Helm Chart.
+
+      License
+
+      This chart is made available under the terms of the Eclipse Public License 2.0
+      which accompanies this distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+      or the Apache License, Version 2.0 which accompanies this distribution and
+      is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+      The JDK binaries installed by this chart are licensed under the GPLv2+CE.
+    digest: c3690450d10ebbe8d021c4c1020ce97ad3a61eed01a8ba9f2e95f967f0bd8977
+    icon: https://pbs.twimg.com/profile_images/910853900181364736/bmWkKoLn_400x400.jpg
+    keywords:
+    - amd64
+    - ppc64le
+    - Java
+    - Eclipse
+    - OpenJ9
+    - JITServer
+    - JVM
+    - JIT
+    name: openj9-jitserver-chart
+    type: application
+    urls:
+    - https://github.com/eclipse-openj9/openj9-utils/files/9446157/openj9-jitserver-chart-0.33.1.tar.gz
+    version: 0.33.1
+  - apiVersion: v2
     appVersion: 0.32.0
     created: "2022-05-11T16:56:19.678142921Z"
     description: |-
@@ -202,4 +232,4 @@ entries:
     urls:
     - https://github.com/eclipse/openj9-utils/files/5825427/openj9-jitserver-chart-0.24.0.tar.gz
     version: 0.24.0
-generated: "2022-05-11T16:56:19.6774377Z"
+generated: "2022-08-29T09:15:06.658746679-07:00"

--- a/helm-chart/openj9-jitserver-chart/Chart.yaml
+++ b/helm-chart/openj9-jitserver-chart/Chart.yaml
@@ -44,6 +44,6 @@ keywords:
   - JVM
   - JIT
 type: application
-version: 0.32.0
-appVersion: 0.32.0
+version: 0.33.1
+appVersion: 0.33.1
 icon: https://pbs.twimg.com/profile_images/910853900181364736/bmWkKoLn_400x400.jpg

--- a/helm-chart/openj9-jitserver-chart/README.md
+++ b/helm-chart/openj9-jitserver-chart/README.md
@@ -57,6 +57,7 @@ OpenJ9 Release | Java 8             | Java 11              | Java 17
 0.30.0         | open-8u322-b06-jre | open-11.0.14_8-jre   | open-17.0.2_8-jre
 0.30.1         |                    | open-11.0.14.1_1-jre |
 0.32.0         | open-8u332-b09-jre | open-11.0.15_10-jre  | open-17.0.3_7-jre
+0.33.1         | open-8u345-b01-jre | open-11.0.16.1_1-jre | open-17.0.4.1_1-jre
 
 **Note:** up until release 0.26.0, OpenJ9 JVM images could be found in the [AdoptOpenJDK](https://hub.docker.com/_/adoptopenjdk) repo of Docker Hub. Starting with release 0.27.0, OpenJ9 JVM images can be pulled from their new repo, [IBM Semeru Runtimes](https://hub.docker.com/_/ibm-semeru-runtimes) in Docker Hub.
 

--- a/helm-chart/openj9-jitserver-chart/values.yaml
+++ b/helm-chart/openj9-jitserver-chart/values.yaml
@@ -24,7 +24,7 @@ replicaCount: 1
 
 image:
   repository: ibm-semeru-runtimes
-  tag: open-8u332-b09-jre
+  tag: open-8u345-b01-jre
   pullPolicy: IfNotPresent
 
 env:
@@ -70,7 +70,7 @@ resources:
   # Resource allocated
   requests:
     cpu: 1
-    memory: 512Mi
+    memory: 1Gi
 
 nodeSelector: {}
 
@@ -81,7 +81,7 @@ affinity:
     requiredDuringSchedulingIgnoredDuringExecution:
       nodeSelectorTerms:
       - matchExpressions:
-        - key: beta.kubernetes.io/arch
+        - key: kubernetes.io/arch
           operator: In
           values:
           - amd64


### PR DESCRIPTION
- Update JITServer Helm chart to default to Java8 OpenJ9 release 0.33.1
- Increase the default memory request value to 1GB
- Change beta.kubernetes.io/arch to kubernetes.io/arch because the former is deprecated
- Update README with docker images OpenJ9 release 0.33.1 for Java8, 11 and 17

Signed-off-by: Marius Pirvu <mpirvu@ca.ibm.com>