### PR TITLE
Update JITServer Helm chart for OpenJ9 release 0.36.0

### DIFF
--- a/helm-chart/index.yaml
+++ b/helm-chart/index.yaml
@@ -1,5 +1,4 @@
-###############################################################################
-# Copyright (c) 2020, 2022 IBM Corp. and others
+# Copyright (c) 2020, 2023 IBM Corp. and others
 #
 # This program and the accompanying materials are made available under
 # the terms of the Eclipse Public License 2.0 which accompanies this
@@ -22,6 +21,36 @@
 apiVersion: v1
 entries:
   openj9-jitserver-chart:
+  - apiVersion: v2
+    appVersion: 0.36.0
+    created: "2023-03-06T20:39:36.941508047Z"
+    description: |-
+      Eclipse OpenJ9 JITServer Helm Chart.
+
+      License
+
+      This chart is made available under the terms of the Eclipse Public License 2.0
+      which accompanies this distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+      or the Apache License, Version 2.0 which accompanies this distribution and
+      is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+      The JDK binaries installed by this chart are licensed under the GPLv2+CE.
+    digest: 9a3b460f88ed1c4924488ef69055cabecd5b7d74917b4d6fa6ed45e9348dff8a
+    icon: https://pbs.twimg.com/profile_images/910853900181364736/bmWkKoLn_400x400.jpg
+    keywords:
+    - amd64
+    - ppc64le
+    - Java
+    - Eclipse
+    - OpenJ9
+    - JITServer
+    - JVM
+    - JIT
+    name: openj9-jitserver-chart
+    type: application
+    urls:
+    - https://github.com/eclipse-openj9/openj9-utils/files/10902590/openj9-jitserver-chart-0.36.0.tar.gz
+    version: 0.36.0
   - apiVersion: v2
     appVersion: 0.35.0
     created: "2022-11-11T19:01:00.25044297Z"
@@ -262,4 +291,4 @@ entries:
     urls:
     - https://github.com/eclipse/openj9-utils/files/5825427/openj9-jitserver-chart-0.24.0.tar.gz
     version: 0.24.0
-generated: "2022-11-11T19:01:00.249717821Z"
+generated: "2023-03-06T20:39:36.936885916Z"

--- a/helm-chart/openj9-jitserver-chart/Chart.yaml
+++ b/helm-chart/openj9-jitserver-chart/Chart.yaml
@@ -44,6 +44,6 @@ keywords:
   - JVM
   - JIT
 type: application
-version: 0.35.0
-appVersion: 0.35.0
+version: 0.36.0
+appVersion: 0.36.0
 icon: https://pbs.twimg.com/profile_images/910853900181364736/bmWkKoLn_400x400.jpg

--- a/helm-chart/openj9-jitserver-chart/README.md
+++ b/helm-chart/openj9-jitserver-chart/README.md
@@ -59,6 +59,7 @@ OpenJ9 Release | Java 8             | Java 11              | Java 17
 0.32.0         | open-8u332-b09-jre | open-11.0.15_10-jre  | open-17.0.3_7-jre
 0.33.1         | open-8u345-b01-jre | open-11.0.16.1_1-jre | open-17.0.4.1_1-jre
 0.35.0         | open-8u352-b08-jre | open-11.0.17_8-jre   | open-17.0.5_8-jre
+0.36.0         | open-8u362-b09-jre | open-11.0.18_10-jre  | open-17.0.6_10-jre
 
 **Note:** up until release 0.26.0, OpenJ9 JVM images could be found in the [AdoptOpenJDK](https://hub.docker.com/_/adoptopenjdk) repo of Docker Hub. Starting with release 0.27.0, OpenJ9 JVM images can be pulled from their new repo, [IBM Semeru Runtimes](https://hub.docker.com/_/ibm-semeru-runtimes) in Docker Hub.
 

--- a/helm-chart/openj9-jitserver-chart/values.yaml
+++ b/helm-chart/openj9-jitserver-chart/values.yaml
@@ -24,7 +24,7 @@ replicaCount: 1
 
 image:
   repository: ibm-semeru-runtimes
-  tag: open-8u352-b08-jre
+  tag: open-8u362-b09-jre
   pullPolicy: IfNotPresent
 
 env:


### PR DESCRIPTION
[openj9-jitserver-chart-0.36.0.tar.gz](https://github.com/eclipse-openj9/openj9-utils/files/10902590/openj9-jitserver-chart-0.36.0.tar.gz)
