### PR TITLE
Update JITServer Helm chart for OpenJ9 release 0.44.0

### DIFF
--- a/helm-chart/index.yaml
+++ b/helm-chart/index.yaml
@@ -23,6 +23,36 @@ apiVersion: v1
 entries:
   openj9-jitserver-chart:
   - apiVersion: v2
+    appVersion: 0.44.0
+    created: "2024-10-19T01:39:38.39317108Z"
+    description: | -
+      Eclipse OpenJ9 JITServer Helm Chart.
+
+      License
+
+      This chart is made available under the terms of the Eclipse Public License 2.0
+      which accompanies this distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+      or the Apache License, Version 2.0 which accompanies this distribution and
+      is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+      The JDK binaries installed by this chart are licensed under the GPLv2+CE.
+    digest: d9e42e3ac8bc648841f8d17c872d686dc375ba5e5955dd3628e13bdbd961d2f8
+    icon: https://pbs.twimg.com/profile_images/910853900181364736/bmWkKoLn_400x400.jpg
+    keywords:
+    - amd64
+    - ppc64le
+    - Java
+    - Eclipse
+    - OpenJ9
+    - JITServer
+    - JVM
+    - JIT
+    name: openj9-jitserver-chart
+    type: application
+    urls:
+    - https://github.com/user-attachments/files/17442088/openj9-jitserver-chart-0.44.0.tar.gz
+    version: 0.44.0
+  - apiVersion: v2
     appVersion: 0.43.0
     created: "2024-03-06T19:28:04.686842593Z"
     description: |-
@@ -412,4 +442,4 @@ entries:
     urls:
     - https://github.com/eclipse/openj9-utils/files/5825427/openj9-jitserver-chart-0.24.0.tar.gz
     version: 0.24.0
-generated: "2024-03-06T19:28:04.686124881Z"
+generated: "2024-10-19T01:39:38.392400897Z"

--- a/helm-chart/openj9-jitserver-chart/Chart.yaml
+++ b/helm-chart/openj9-jitserver-chart/Chart.yaml
@@ -44,6 +44,6 @@ keywords:
   - JVM
   - JIT
 type: application
-version: 0.43.0
-appVersion: 0.43.0
+version: 0.44.0
+appVersion: 0.44.0
 icon: https://pbs.twimg.com/profile_images/910853900181364736/bmWkKoLn_400x400.jpg

--- a/helm-chart/openj9-jitserver-chart/README.md
+++ b/helm-chart/openj9-jitserver-chart/README.md
@@ -49,22 +49,22 @@ JCL      - b7b5b42ea6 based on jdk-11.0.15+10)
 Find the corresponding image from [IBM Semeru Runtimes Docker Hub](https://hub.docker.com/_/ibm-semeru-runtimes) through keyword search of architecture, Java version and release. In this example, `0.32.0` release of Java 11 is used in the application image, thus the corresponding image with tag is [`ibm-semeru-runtimes:open-11.0.15_10-jre`](https://hub.docker.com/layers/ibm-semeru-runtimes/library/ibm-semeru-runtimes/open-11.0.15_10-jre/images/sha256-a7f2c008c986dd45e22c764333a7182ab0872d80d52f3e5e8d1195b3a3a0108b?context=explore). The image tag `open-11.0.15_10-jre` will be used in the following step. For convenience, [Table 1](#table-1-image-tags-from-ibm-semeru-runtimes-repository-in-docker-hub) below lists all IBM Semeru Runtimes tags per OpenJ9 release and Java version.
 
 #### Table 1. Image tags from IBM Semeru Runtimes repository in Docker Hub
-OpenJ9 Release | Java 8             | Java 11              | Java 17
----------------|--------------------|----------------------|------------------
-0.27.0         | open-8u302-b08-jre | open-11.0.12_7-jre   |
-0.29.0         | open-8u312-b07-jre | open-11.0.13_8-jre   |
-0.29.1         |                    |                      | open-17.0.1_12-jre
-0.30.0         | open-8u322-b06-jre | open-11.0.14_8-jre   | open-17.0.2_8-jre
-0.30.1         |                    | open-11.0.14.1_1-jre |
-0.32.0         | open-8u332-b09-jre | open-11.0.15_10-jre  | open-17.0.3_7-jre
-0.33.1         | open-8u345-b01-jre | open-11.0.16.1_1-jre | open-17.0.4.1_1-jre
-0.35.0         | open-8u352-b08-jre | open-11.0.17_8-jre   | open-17.0.5_8-jre
-0.36.0         | open-8u362-b09-jre | open-11.0.18_10-jre  | open-17.0.6_10-jre
-0.38.0         | open-8u372-b07-jre | open-11.0.19_7-jre   | open-17.0.7_7-jre
-0.40.0         | open-8u382-b05-jre | open-11.0.20_8-jre   | open-17.0.8_7-jre
-0.41.0         | open-8u392-b08-jre | open-11.0.21_9-jre   | open-17.0.9_9-jre
-0.43.0         | open-8u402-b06-jre | open-11.0.22_7-jre   | open-17.0.10_7-jre
-
+OpenJ9 Release | Java 8             | Java 11              | Java 17            | Java 21
+---------------|--------------------|----------------------|--------------------|--------------
+0.27.0         | open-8u302-b08-jre | open-11.0.12_7-jre   |                    |
+0.29.0         | open-8u312-b07-jre | open-11.0.13_8-jre   |                    |
+0.29.1         |                    |                      | open-17.0.1_12-jre |
+0.30.0         | open-8u322-b06-jre | open-11.0.14_8-jre   | open-17.0.2_8-jre  |
+0.30.1         |                    | open-11.0.14.1_1-jre |                    |
+0.32.0         | open-8u332-b09-jre | open-11.0.15_10-jre  | open-17.0.3_7-jre  |
+0.33.1         | open-8u345-b01-jre | open-11.0.16.1_1-jre | open-17.0.4.1_1-jre|
+0.35.0         | open-8u352-b08-jre | open-11.0.17_8-jre   | open-17.0.5_8-jre  |
+0.36.0         | open-8u362-b09-jre | open-11.0.18_10-jre  | open-17.0.6_10-jre |
+0.38.0         | open-8u372-b07-jre | open-11.0.19_7-jre   | open-17.0.7_7-jre  |
+0.40.0         | open-8u382-b05-jre | open-11.0.20_8-jre   | open-17.0.8_7-jre  |
+0.41.0         | open-8u392-b08-jre | open-11.0.21_9-jre   | open-17.0.9_9-jre  |
+0.43.0         | open-8u402-b06-jre | open-11.0.22_7-jre   | open-17.0.10_7-jre |
+0.44.0         | open-8u412-b08-jre | open-11.0.23_9-jre   | open-17.0.11_9-jre | open-21.0.3_9-jre
 
 
 **Note:** up until release 0.26.0, OpenJ9 JVM images could be found in the [AdoptOpenJDK](https://hub.docker.com/_/adoptopenjdk) repo of Docker Hub. Starting with release 0.27.0, OpenJ9 JVM images can be pulled from their new repo, [IBM Semeru Runtimes](https://hub.docker.com/_/ibm-semeru-runtimes) in Docker Hub.
@@ -89,7 +89,7 @@ image:
   tag: open-8u332-b09-jre
 ```
 
-Currently, JITServer is supported on Java versions 8, 11 and 17.
+Currently, JITServer is supported on Java versions 8, 11, 17 and 21.
 
 ### 2. Enable your application to use JITServer.
 Once the JITServer is deployed, you can enable your application to use JITServer by adding the following JVM options as an environment variable into your Java application container.
@@ -247,4 +247,4 @@ This chart does not require PodDisruptionBudgets to be bound to the target names
 
 ## Limitations
 * Deploys on Linux on x86-64, Linux on Power and Linux on Z 64-bit only. In the future other platforms may be supported as well.
-* Supports Java 8, Java 11 and Java17 only. For the most up to date information, please check the [JITServer technology introduction](https://www.eclipse.org/openj9/docs/jitserver/).
+* Supports Java 8, Java 11, Java17 and Java21 only. For the most up to date information, please check the [JITServer technology introduction](https://www.eclipse.org/openj9/docs/jitserver/).

--- a/helm-chart/openj9-jitserver-chart/values.yaml
+++ b/helm-chart/openj9-jitserver-chart/values.yaml
@@ -24,7 +24,7 @@ replicaCount: 1
 
 image:
   repository: ibm-semeru-runtimes
-  tag: open-8u402-b06-jre
+  tag: open-8u412-b08-jre
   pullPolicy: IfNotPresent
 
 env:


### PR DESCRIPTION
[openj9-jitserver-chart-0.44.0.tar.gz](https://github.com/user-attachments/files/17442088/openj9-jitserver-chart-0.44.0.tar.gz)
