### PR TITLE
Update JITServer Helm chart for release 0.48.0

### DIFF
--- a/helm-chart/index.yaml
+++ b/helm-chart/index.yaml
@@ -23,6 +23,36 @@ apiVersion: v1
 entries:
   openj9-jitserver-chart:
   - apiVersion: v2
+    appVersion: 0.48.0
+    created: "2024-12-04T02:33:30.482229709Z"
+    description: |-
+      Eclipse OpenJ9 JITServer Helm Chart.
+
+      License
+
+      This chart is made available under the terms of the Eclipse Public License 2.0
+      which accompanies this distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+      or the Apache License, Version 2.0 which accompanies this distribution and
+      is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+      The JDK binaries installed by this chart are licensed under the GPLv2+CE.
+    digest: 6e0fb4a3333bafbf4e86b51678feb02894fbae2d5f9b7ccc267a064b4c2f129d
+    icon: https://pbs.twimg.com/profile_images/910853900181364736/bmWkKoLn_400x400.jpg
+    keywords:
+    - amd64
+    - ppc64le
+    - Java
+    - Eclipse
+    - OpenJ9
+    - JITServer
+    - JVM
+    - JIT
+    name: openj9-jitserver-chart
+    type: application
+    urls:
+    - https://github.com/user-attachments/files/18001828/openj9-jitserver-chart-0.48.0.tar.gz
+    version: 0.48.0
+  - apiVersion: v2
     appVersion: 0.46.1
     created: "2024-10-22T00:38:00.943354962Z"
     description: |-
@@ -472,4 +502,4 @@ entries:
     urls:
     - https://github.com/eclipse/openj9-utils/files/5825427/openj9-jitserver-chart-0.24.0.tar.gz
     version: 0.24.0
-generated: "2024-10-22T00:38:00.9425641Z"
+generated: "2024-12-04T02:33:30.481428332Z"

--- a/helm-chart/openj9-jitserver-chart/Chart.yaml
+++ b/helm-chart/openj9-jitserver-chart/Chart.yaml
@@ -44,6 +44,6 @@ keywords:
   - JVM
   - JIT
 type: application
-version: 0.46.1
-appVersion: 0.46.1
+version: 0.48.0
+appVersion: 0.48.0
 icon: https://pbs.twimg.com/profile_images/910853900181364736/bmWkKoLn_400x400.jpg

--- a/helm-chart/openj9-jitserver-chart/README.md
+++ b/helm-chart/openj9-jitserver-chart/README.md
@@ -66,6 +66,7 @@ OpenJ9 Release | Java 8             | Java 11              | Java 17            
 0.43.0         | open-8u402-b06-jre | open-11.0.22_7-jre   | open-17.0.10_7-jre |
 0.44.0         | open-8u412-b08-jre | open-11.0.23_9-jre   | open-17.0.11_9-jre | open-21.0.3_9-jre
 0.46.1         | open-8u422-b05-jre | open-11.0.24_8-jre   | open-17.0.12_7-jre | open-21.0.4_7-jre
+0.48.0         | open-8u432-b06-jre | open-11.0.25_9-jre   | open-17.0.13_11-jre| open-21.0.5_11-jre
 
 
 **Note:** up until release 0.26.0, OpenJ9 JVM images could be found in the [AdoptOpenJDK](https://hub.docker.com/_/adoptopenjdk) repo of Docker Hub. Starting with release 0.27.0, OpenJ9 JVM images can be pulled from their new repo, [IBM Semeru Runtimes](https://hub.docker.com/_/ibm-semeru-runtimes) in Docker Hub.

--- a/helm-chart/openj9-jitserver-chart/values.yaml
+++ b/helm-chart/openj9-jitserver-chart/values.yaml
@@ -24,7 +24,7 @@ replicaCount: 1
 
 image:
   repository: ibm-semeru-runtimes
-  tag: open-8u422-b05-jre
+  tag: open-8u432-b06-jre
   pullPolicy: IfNotPresent
 
 env:


### PR DESCRIPTION
[openj9-jitserver-chart-0.48.0.tar.gz](https://github.com/user-attachments/files/18001828/openj9-jitserver-chart-0.48.0.tar.gz)
