### PR TITLE
Update JITServer Helm chart for release 0.51.0

### DIFF
--- a/helm-chart/index.yaml
+++ b/helm-chart/index.yaml
@@ -23,6 +23,36 @@ apiVersion: v1
 entries:
   openj9-jitserver-chart:
   - apiVersion: v2
+    appVersion: 0.51.0
+    created: "2025-07-18T15:28:21.007759322Z"
+    description: |-
+      Eclipse OpenJ9 JITServer Helm Chart.
+
+      License
+
+      This chart is made available under the terms of the Eclipse Public License 2.0
+      which accompanies this distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+      or the Apache License, Version 2.0 which accompanies this distribution and
+      is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+      The JDK binaries installed by this chart are licensed under the GPLv2+CE.
+    digest: 4672c6c1b32a3e89864aa87ff8b496ad34e86271be1c5a8d23fb61757262a8d2
+    icon: https://pbs.twimg.com/profile_images/910853900181364736/bmWkKoLn_400x400.jpg
+    keywords:
+    - amd64
+    - ppc64le
+    - Java
+    - Eclipse
+    - OpenJ9
+    - JITServer
+    - JVM
+    - JIT
+    name: openj9-jitserver-chart
+    type: application
+    urls:
+    - https://github.com/user-attachments/files/21319273/openj9-jitserver-chart-0.51.0.tar.gz
+    version: 0.51.0
+  - apiVersion: v2
     appVersion: 0.49.0
     created: "2025-03-03T20:39:49.754196848Z"
     description: |-
@@ -532,4 +562,4 @@ entries:
     urls:
     - https://github.com/eclipse/openj9-utils/files/5825427/openj9-jitserver-chart-0.24.0.tar.gz
     version: 0.24.0
-generated: "2025-03-03T20:39:49.753393513Z"
+generated: "2025-07-18T15:28:21.006965673Z"

--- a/helm-chart/openj9-jitserver-chart/Chart.yaml
+++ b/helm-chart/openj9-jitserver-chart/Chart.yaml
@@ -44,6 +44,6 @@ keywords:
   - JVM
   - JIT
 type: application
-version: 0.49.0
-appVersion: 0.49.0
+version: 0.51.0
+appVersion: 0.51.0
 icon: https://pbs.twimg.com/profile_images/910853900181364736/bmWkKoLn_400x400.jpg

--- a/helm-chart/openj9-jitserver-chart/README.md
+++ b/helm-chart/openj9-jitserver-chart/README.md
@@ -68,6 +68,7 @@ OpenJ9 Release | Java 8             | Java 11              | Java 17            
 0.46.1         | open-8u422-b05-jre | open-11.0.24_8-jre   | open-17.0.12_7-jre | open-21.0.4_7-jre
 0.48.0         | open-8u432-b06-jre | open-11.0.25_9-jre   | open-17.0.13_11-jre| open-21.0.5_11-jre
 0.49.0         | open-8u442-b06-jre | open-11.0.26_4-jre   | open-17.0.14_7-jre | open-21.0.6_7-jre
+0.51.0         | open-8u452-b09-jre | open-11.0.27_6-jre   | open-17.0.15_6-jre | open-21.0.7_6-jre
 
 
 **Note:** up until release 0.26.0, OpenJ9 JVM images could be found in the [AdoptOpenJDK](https://hub.docker.com/_/adoptopenjdk) repo of Docker Hub. Starting with release 0.27.0, OpenJ9 JVM images can be pulled from their new repo, [IBM Semeru Runtimes](https://hub.docker.com/_/ibm-semeru-runtimes) in Docker Hub.

--- a/helm-chart/openj9-jitserver-chart/values.yaml
+++ b/helm-chart/openj9-jitserver-chart/values.yaml
@@ -24,7 +24,7 @@ replicaCount: 1
 
 image:
   repository: ibm-semeru-runtimes
-  tag: open-8u442-b06-jre
+  tag: open-8u452-b09-jre
   pullPolicy: IfNotPresent
 
 env:


### PR DESCRIPTION
[openj9-jitserver-chart-0.51.0.tar.gz](https://github.com/user-attachments/files/21319273/openj9-jitserver-chart-0.51.0.tar.gz)
